### PR TITLE
Xuandong

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -122,7 +122,7 @@ oauth.register(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[f"http://{os.getenv('HOST_FRONT_END', '0.0.0.0')}:{int(os.getenv('PORT_FRONT_END', 8080))}", "http://localhost:3000"],
+    allow_origins=[f"http://{os.getenv('HOST_FRONT_END', '0.0.0.0')}:{int(os.getenv('PORT_FRONT_END', 8080))}", f"http://10.100.200.119:{int(os.getenv('PORT_FRONT_END', 8080))}"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -286,7 +286,7 @@ async def auth(request: Request):
 
 
 @app.get("/logout")
-async def logout(request: Request, ):
+async def logout(request: Request):
     request.session.pop("user", None)
     return RedirectResponse(url="/")
 

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -122,7 +122,7 @@ oauth.register(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[f"http://{os.getenv('HOST_FRONT_END', '0.0.0.0')}:{int(os.getenv('PORT_FRONT_END', 8080))}", f"http://10.100.200.119:{int(os.getenv('PORT_FRONT_END', 8080))}"],
+    allow_origins=[f"http://{os.getenv('HOST_FRONT_END', '0.0.0.0')}:{int(os.getenv('PORT_FRONT_END', 8080))}", f"http://{os.getenv('HOST_SERVER', '0.0.0.0')}:{int(os.getenv('PORT_FRONT_END', 8080))}"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -49,7 +49,7 @@ from data.uci import get_data_uci_where_id, format_data_automl
 from fastapi.responses import JSONResponse
 from data.engine import get_list_data, get_one_data, get_all_data
 from data.engine import upload_data_to_minio, update_dataset_to_minio_by_id, delete_dataset_at_minio_by_id
-from users.engine import get_current_admin
+from users.engine import get_current_admin, get_current_user
 from database.database import connection
 
 # Lấy danh sách user
@@ -286,7 +286,7 @@ async def auth(request: Request):
 
 
 @app.get("/logout")
-async def logout(request: Request):
+async def logout(request: Request, ):
     request.session.pop("user", None)
     return RedirectResponse(url="/")
 

--- a/src/backend/automl/search/factory/search_strategy_factory.py
+++ b/src/backend/automl/search/factory/search_strategy_factory.py
@@ -23,7 +23,7 @@ class SearchStrategyFactory:
     @classmethod
     def create_strategy(cls, strategy_name: str, config: Optional[Dict[str, Any]] = None) -> SearchStrategy:
         """
-        Create a search strategy instance based on the strategy name.
+        Create a search strategy instance based on the strategy name
         
         Args:
             strategy_name: Name of the search strategy (e.g., 'grid', 'genetic', 'bayesian')

--- a/src/backend/automl/v2/master.py
+++ b/src/backend/automl/v2/master.py
@@ -90,7 +90,7 @@ task_counter = itertools.count()
 # =========================================================================
 # LOGIC CỦA JOB
 # =========================================================================
-async def setup_job_tasks(job_id: str, id_data: str, id_user: str, config: dict):
+async def setup_job_tasks(job_id: str, id_data: str, id_user: str, config: dict, cache_key: str):
     """
     Tạo task và bỏ vào hàng đợi ưu tiên toàn cục
     """
@@ -99,7 +99,7 @@ async def setup_job_tasks(job_id: str, id_data: str, id_user: str, config: dict)
 
     list_feature = config.get('list_feature', [])
     target = config.get('target', '')
-    cache_key = get_config_hash(id_data, list_feature, target)
+    # cache_key = get_config_hash(id_data, list_feature, target)
     
 
     JOB_TRACKER[job_id] = {

--- a/src/backend/automl/v2/master.py
+++ b/src/backend/automl/v2/master.py
@@ -68,7 +68,7 @@ def get_config_hash(id_data: str, list_feature: list, target: str) -> str:
 GLOBAL_TASK_QUEUE = asyncio.PriorityQueue()
 
 # Hàng đợi riêng cho từng Data ID
-# Key: id_data, Value: asyncio.Queue (FIFO)
+# Key: task_cache_key, Value: asyncio.Queue (FIFO)
 LOCAL_QUEUES: dict[str, asyncio.Queue] = {}
 
 # Lock để bảo vệ việc tạo hàng đợi mới trong LOCAL_QUEUES
@@ -97,8 +97,8 @@ async def setup_job_tasks(job_id: str, id_data: str, id_user: str, config: dict)
     was_queue_empty = GLOBAL_TASK_QUEUE.empty()
     models, metric_list = await asyncio.to_thread(get_models)
 
-    list_feature = config.get('list_feature')
-    target = config.get('target')
+    list_feature = config.get('list_feature', [])
+    target = config.get('target', '')
     cache_key = get_config_hash(id_data, list_feature, target)
     
 

--- a/src/backend/automl/v2/master.py
+++ b/src/backend/automl/v2/master.py
@@ -263,6 +263,17 @@ async def handle_task_result_submission(result: dict, db: AsyncDatabase):
     return {"status": "success"}
 
 
+def _register_active_task(task, worker_url, entry_count):
+    task_id = task["task_id"]
+    ACTIVE_TASKS[task_id] = {
+        "worker_url": worker_url,
+        "start_time": time.time(),
+        "task_data": task,
+        "entry_count": entry_count,
+        "snooze_count": 0
+    }
+    return task
+
 
 async def get_prioritized_task(worker_url: str, cached_key_hint: str | None = None):
     """
@@ -284,56 +295,58 @@ async def get_prioritized_task(worker_url: str, cached_key_hint: str | None = No
                 pass
 
     if task:
-        task_id = task["task_id"]
-        ACTIVE_TASKS[task_id] = {
-            "worker_url": worker_url,
-            "start_time": time.time(),
-            "task_data": task,
-            "entry_count": -1, # Task từ LOCAL không cần entry_count
-            "snooze_count": 0
-        }
-        return task
+        return _register_active_task(task, worker_url, -1)
 
-    # Nếu không có task ở LOCAL, lấy từ GLOBAL
-    # Tìm được task phù hợp cho worker
-    # hoặc hàng đọi GLOBAL hết
+    # Master sẽ rút task từ Global. Nếu task không khớp cache của worker,
+    # Master sẽ "cất" nó vào Local Queue tương ứng thay vì đưa cho worker này.
     while True:
         try:
             priority, entry_count, task = GLOBAL_TASK_QUEUE.get_nowait()
         except asyncio.QueueEmpty:
-            return None
+            break # Global hết task, thoát khỏi vòng lặp
         
-        cache_key = task.get("cache_key")
+        task_cache_key = task.get("cache_key")
 
-        # Worker không có cache. Task nào cũng phù hợp
+        # Trường hợp 1: Worker mới tinh (không có cache) -> Nhận luôn
         if not cached_key_hint:
-            break
+            return _register_active_task(task, worker_url, entry_count)
 
-        # Worker có cache và task này HIT cache
-        if cached_key_hint == cache_key:
-            break
+        # Trường hợp 2: Worker có cache, và task này khớp -> Nhận luôn
+        if cached_key_hint == task_cache_key:
+            return _register_active_task(task, worker_url, entry_count)
 
-        # Worker có cache nhưng task này MISS cache
+        # Trường hợp 3: Worker có cache, nhưng task khác cache (MISS)
         else:
+            # Cất task này vào hàng đợi Local tương ứng của nó
             local_queue_miss = None
             async with LOCAL_QUEUE_LOCK:
-                if cache_key not in LOCAL_QUEUES:
-                    LOCAL_QUEUES[cache_key] = asyncio.Queue()
-                local_queue_miss = LOCAL_QUEUES[cache_key]
+                if task_cache_key not in LOCAL_QUEUES:
+                    LOCAL_QUEUES[task_cache_key] = asyncio.Queue()
+                local_queue_miss = LOCAL_QUEUES[task_cache_key]
             
             await local_queue_miss.put(task)
             task = None
-    
-    if task:
-        task_id = task["task_id"]
-        ACTIVE_TASKS[task_id] = {
-            "worker_url": worker_url,
-            "start_time": time.time(),
-            "task_data": task,
-            "entry_count": entry_count,
-            "snooze_count": 0
-        }
-        return task
+
+    if cached_key_hint:
+        # Duyệt qua tất cả các Local Queue khác đang có task
+        async with LOCAL_QUEUE_LOCK:
+            # Lấy danh sách các key để tránh lỗi runtime khi dict thay đổi
+            all_keys = list(LOCAL_QUEUES.keys())
+        
+        for key in all_keys:
+            # Bỏ qua queue của chính worker (vì đã check rồi)
+            if key == cached_key_hint:
+                continue
+
+            target_queue = LOCAL_QUEUES.get(key)
+            if target_queue:
+                try:
+                    # Lấy trộm task từ queue của key khác
+                    task = target_queue.get_nowait()
+                    print(f"[Master] Fallback: Worker {worker_url} (Hint: {cached_key_hint}) assigned task for new key: {key}")
+                    return _register_active_task(task, worker_url, -1)
+                except asyncio.QueueEmpty:
+                    continue
     
     return None
 

--- a/src/backend/automl/v2/minio.py
+++ b/src/backend/automl/v2/minio.py
@@ -23,14 +23,14 @@ load_dotenv()
 # Truy cập các biến môi trường
 MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY")
-MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY") 
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY")
 
 class MinIOStorage:
     def __init__(self, endpoint, access_key, secret_key, secure=False):
         try:
             if not all([endpoint, access_key, secret_key]):
                 raise ValueError("Not found environment variables")
-            
+
             self.__client = Minio(
                 endpoint,
                 access_key=access_key,
@@ -39,7 +39,7 @@ class MinIOStorage:
             )
         except Exception as e:
             raise Exception(f"MinIO initialization error: {e}")
-    
+
 
     def uploaded_object(self, bucket_name: str, object_name: str, object_bytes: bytes):
         try:

--- a/src/backend/database/get_dataset.py
+++ b/src/backend/database/get_dataset.py
@@ -6,19 +6,16 @@ from bson.objectid import ObjectId
 import pyarrow.parquet as pq
 import time
 from pymongo.asynchronous.database import AsyncDatabase
-from fastapi import Depends
 
 # Local Modules
 from automl.v2.minio import minIOStorage
 from automl.process_data import preprocess_data
-from database.database import get_db
 
 
 class MongoDataLoader:
     def __init__(self, db: AsyncDatabase):
         self.__data_collection = db.tbl_Data
 
-    # database đang xử lý đồng bộ
     async def _get_data_link_from_db(self, id_data: str) -> tuple[str | None, str | None]:
         """Lấy data link từ MongoDB theo ID"""
 
@@ -41,13 +38,15 @@ class MongoDataLoader:
             parquet_stream = minIOStorage.get_object(bucket_name, object_name)
             df_retrieved = pd.read_parquet(parquet_stream)
 
+            total_rows = len(df_retrieved)
             df_preview = df_retrieved.head(num_rows)
 
-            return df_preview
+
+            return df_preview, total_rows
         
         except Exception as e:
             print(f"Exception when get dataset preview: {str(e)}")
-            return None
+            return None, 0
 
 
     async def get_data_features(self, id_data: str) -> list | None:

--- a/src/backend/experiment.py
+++ b/src/backend/experiment.py
@@ -41,7 +41,7 @@ async def get_features_of_dataset(id_data: str, request: Request):
 async def get_features_of_dataset(id_data: str, request: Request):
     dataset = MongoDataLoader(request.app.state.db)
     try:
-        data_preview = await dataset.get_data_preview(id_data)
+        data_preview, total_rows = await dataset.get_data_preview(id_data)
 
         if data_preview is None:
             raise HTTPException(
@@ -50,6 +50,7 @@ async def get_features_of_dataset(id_data: str, request: Request):
             )
         
         return {
+            "rows": total_rows,
             "data": data_preview.to_dict(orient='records')
         }
     except ValueError as ve:

--- a/src/backend/kafka_consumer.py
+++ b/src/backend/kafka_consumer.py
@@ -58,12 +58,12 @@ async def handle_training_job(job_id: str, id_data: str, id_user: str, config: d
         # Sử dụng 2 định dạng:
         """
         parquet - cho việc lưu trữ lâu dài (tốn ít tài nguyên)
-        feather - cho việc đọc ghi (tối ưu hóa về tốc độ)
+        numpy array - cho việc cache dataset
         """
         cache_bucket = "cache"
         models_bucket = "models"
-        list_feature = config.get("list_feature")
-        target = config.get("target")
+        list_feature = config.get("list_feature", [])
+        target = config.get("target", "")
 
         config_hash = get_config_hash(id_data, list_feature, target)
         data_cache_path = f"{id_data}/{config_hash}.npz"
@@ -121,7 +121,7 @@ async def handle_training_job(job_id: str, id_data: str, id_user: str, config: d
         )
             
         # Đăng ký task vào hàng đợi
-        await setup_job_tasks(job_id, id_data, id_user, config)
+        await setup_job_tasks(job_id, id_data, id_user, config, config_hash)
         print(f"[Consumer] Successfully submitted job {job_id} to Master")
     except Exception as e:
         print(f"[Consumer] Failed to handle job {job_id}: {e}")

--- a/src/backend/temp.env
+++ b/src/backend/temp.env
@@ -17,6 +17,8 @@ WORKER_HOST="0.0.0.0"
 WORKER_PORT=4000
 
 ### MASTER SETTINGS ###
+HOST_SERVER="10.0.0.0"
+
 # Configuration when running distributed in production
 NUMBER_WORKERS=1
 

--- a/src/backend/users/engine.py
+++ b/src/backend/users/engine.py
@@ -128,7 +128,7 @@ async def check_token(token, db: AsyncDatabase):
         raise HTTPException(status_code=401, detail="Token đã hết hạn!")
     except jwt.PyJWTError:
         raise HTTPException(status_code=401, detail="Token không hợp lệ!")
-    
+
 from fastapi import HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 
@@ -144,7 +144,7 @@ async def get_current_user(db: AsyncDatabase = Depends(get_db), token: str = Dep
 async def get_current_admin(current_user: dict = Depends(get_current_user)):
     if current_user.get('role') != 'Admin':
         raise HTTPException(status_code=403, detail="Quyền truy cập bị từ chối!")
-    return current_user  
+    return current_user
 
 
 async def handleLogin(username, password, db: AsyncDatabase):

--- a/src/backend/worker.py
+++ b/src/backend/worker.py
@@ -127,7 +127,7 @@ async def _execute_single_training_task(task: dict):
             X_processed,
             y_processed,
             task["metrics"],
-            config.get("metric_sort"),
+            config.get("metric_sort", "accuracy"),
             models_to_train,
             search_algorithm
         )


### PR DESCRIPTION
Lỗi ở mã nguồn trước:
Trong logic lập lịch:
- Trong thiết kế trước, hệ thống sử dụng hàng đợi Local và Global để tối ưu hiệu suất. Tức là Global đẩy từng task vào hàng đợi Local. Hàng đợi local là dict[str, dict] . key là cache_key (dấu hiệu để biết là dùng dataset nào) còn value là metadata của task đó - model và params)
-  Tuy nhiên, điều này tạo ra lỗi khi chuyển giao giữa các job.
- Vấn đề là. khi có job master sẽ lấy data và xử lý đưa vào cache (folder trên minio) và gửi request yêu cầu worker huấn luyện. Worker dựa vào metadata lấy các task để huấn luyện.
- Nhưng khi đó, nếu có job mới tới (khác bộ dữ liệu), thì nó sẽ được đưa vào global và tạo thành 1 dict khác trong hàng đợi local. 
- Khi này vấn đề xảy ra vì logic get_task hiện tại, sẽ duyệt hết trong local['cache_key'], nếu không có task sẽ tìm ở global. Nếu không có task cũng dùng bộ dataset đó thì sẽ thông báo hết task và dừng huấn luyện trong khi vẫn còn các task dùng bộ dữ liệu B
- Giải pháp: thêm cơ chế dự phòng trong hàm get_task. Nếu không tìm thấy task của bộ dataset A và ở global cũng không có task đó, thì sẽ tìm kiếm các items còn lại trong dict để kiểm tra xem có task không và thực hiện huấn luyện tiếp.
- Nếu hoàn toàn không còn task ở cả local và global thì dừng lại.